### PR TITLE
Fix: RegisterPage

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,3 @@
 /api/*  http://13.209.67.42:8080/api/:splat  200
+
+/*  /index.html  200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,1 @@
 /api/*  http://13.209.67.42:8080/api/:splat  200
-
-/*  /index.html  200

--- a/src/components/Register/index.tsx
+++ b/src/components/Register/index.tsx
@@ -29,6 +29,16 @@ function RegisterPage() {
     passwordConfirm: '',
     nickname: '',
   });
+  const [isInputFocused, setIsInputFocused] = useState({
+    username: false,
+    password: false,
+    passwordConfirm: false,
+    nickname: false,
+  });
+  const [isInputHidden, setIsInputHidden] = useState({
+    password: true,
+    passwordConfirm: true,
+  });
   const [isAgreementChecked, setIsAgreementChecked] =
     useState<IsAgreementChecked>({
       agreementAll: false,
@@ -46,23 +56,6 @@ function RegisterPage() {
       ...registerInfo,
       [name]: value,
     });
-
-    let helperValue = '';
-    switch (name) {
-      case 'username':
-        helperValue = (await getUsernameHelper(value)).message;
-        break;
-      case 'password':
-        helperValue = getPasswordHelper(value).message;
-        break;
-      case 'passwordConfirm':
-        helperValue = getPasswordConfirmHelper(value).message;
-        break;
-      case 'nickname':
-        helperValue = (await getNicknameHelper(value)).message;
-        break;
-    }
-    setRegisterHelper({ ...registerHelper, [name]: helperValue });
   };
 
   const onChangeCheckbox = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -94,6 +87,54 @@ function RegisterPage() {
     }
   };
 
+  const onFocusInput = (input: string) => {
+    switch (input) {
+      case 'username':
+        setIsInputFocused((prev) => ({ ...prev, username: true }));
+        break;
+      case 'password':
+        setIsInputFocused((prev) => ({ ...prev, password: true }));
+        break;
+      case 'passwordConfirm':
+        setIsInputFocused((prev) => ({ ...prev, passwordConfirm: true }));
+        break;
+      case 'nickname':
+        setIsInputFocused((prev) => ({ ...prev, nickname: true }));
+        break;
+    }
+  };
+
+  const onClickClear = (input: string) => {
+    switch (input) {
+      case 'username':
+        setRegisterInfo((prev) => ({ ...prev, username: '' }));
+        break;
+      case 'password':
+        setRegisterInfo((prev) => ({ ...prev, password: '' }));
+        break;
+      case 'passwordConfirm':
+        setRegisterInfo((prev) => ({ ...prev, passwordConfirm: '' }));
+        break;
+      case 'nickname':
+        setRegisterInfo((prev) => ({ ...prev, nickname: '' }));
+        break;
+    }
+  };
+
+  const onClickTogglePassword = (input: string) => {
+    switch (input) {
+      case 'password':
+        setIsInputHidden((prev) => ({ ...prev, password: !prev.password }));
+        break;
+      case 'passwordConfirm':
+        setIsInputHidden((prev) => ({
+          ...prev,
+          passwordConfirm: !prev.passwordConfirm,
+        }));
+        break;
+    }
+  };
+
   const onClickRegister = () => {
     apiRegister(
       registerInfo.username,
@@ -109,59 +150,77 @@ function RegisterPage() {
       });
   };
 
-  const getUsernameHelper = async (username: string) => {
-    if (!username) return { message: '아이디는 필수정보입니다.' };
-    if (username.length < 5)
-      return { message: '아이디는 5자 이상이어야 합니다.' };
-    if (!regexUsername.test(username))
-      return {
-        message: '아이디는 영문소문자, 숫자, 특수기호(_)만 사용 가능합니다.',
-      };
-    const response = await apiCheckUsername(username);
-    return response.data.isUnique
-      ? { message: '사용 가능한 아이디입니다.' }
-      : { message: '이미 사용 중인 아이디입니다.' };
-  };
+  const getUsernameHelper = useCallback(
+    async (username: string) => {
+      if (!isInputFocused.username) return { message: '' };
+      if (!username) return { message: '아이디는 필수정보입니다.' };
+      if (username.length < 5)
+        return { message: '아이디는 5자 이상이어야 합니다.' };
+      if (!regexUsername.test(username))
+        return {
+          message: '아이디는 영문소문자, 숫자, 특수기호(_)만 사용 가능합니다.',
+        };
+      const response = await apiCheckUsername(username);
+      return response.data.isUnique
+        ? { message: '사용 가능한 아이디입니다.' }
+        : { message: '이미 사용 중인 아이디입니다.' };
+    },
+    [isInputFocused.username]
+  );
 
-  const getPasswordHelper = (password: string) => {
-    if (!password) return { message: '비밀번호는 필수정보입니다.' };
-    if (password.length < 8)
-      return { message: '8~30자 이내로 입력해 주십시오.' };
-    if (regexRepeat.test(password))
-      return {
-        message: '동일문자를 반복해서 4자 이상 사용할 수 없습니다.',
-      };
-    const combinationCount =
-      Number(regexNumber.test(password)) +
-      Number(regexAlphabet.test(password)) +
-      Number(regexSpecial.test(password));
-    if (combinationCount < 2)
-      return {
-        message:
-          '숫자, 영문 대소문자, 특수문자 중 두가지 이상으로 조합해 주십시오.',
-      };
-    return { message: '' };
-  };
+  const getPasswordHelper = useCallback(
+    (password: string) => {
+      if (!isInputFocused.password) return { message: '' };
+      if (!password) return { message: '비밀번호는 필수정보입니다.' };
+      if (password.length < 8)
+        return { message: '8~30자 이내로 입력해 주십시오.' };
+      if (regexRepeat.test(password))
+        return {
+          message: '동일문자를 반복해서 4자 이상 사용할 수 없습니다.',
+        };
+      const combinationCount =
+        Number(regexNumber.test(password)) +
+        Number(regexAlphabet.test(password)) +
+        Number(regexSpecial.test(password));
+      if (combinationCount < 2)
+        return {
+          message:
+            '숫자, 영문 대소문자, 특수문자 중 두가지 이상으로 조합해 주십시오.',
+        };
+      return { message: '' };
+    },
+    [isInputFocused.password]
+  );
 
   const getPasswordConfirmHelper = useCallback(
     (passwordConfirm: string) => {
-      if (!registerInfo.password) return { message: '' };
+      if (!isInputFocused.passwordConfirm) return { message: '' };
       if (!passwordConfirm)
         return { message: '비밀번호 재확인은 필수정보입니다.' };
       if (passwordConfirm !== registerInfo.password)
         return { message: '비밀번호가 일치하지 않습니다.' };
       return { message: '' };
     },
-    [registerInfo.password]
+    [registerInfo.password, isInputFocused.passwordConfirm]
   );
 
-  const getNicknameHelper = async (nickname: string) => {
-    if (!nickname) return { message: '닉네임은 필수정보입니다.' };
-    const response = await apiCheckNickname(nickname);
-    return response.data.isUnique
-      ? { message: '사용 가능한 닉네임입니다.' }
-      : { message: '이미 사용 중인 닉네임입니다.' };
-  };
+  const getNicknameHelper = useCallback(
+    async (nickname: string) => {
+      if (!isInputFocused.nickname) return { message: '' };
+      if (!nickname) return { message: '닉네임은 필수정보입니다.' };
+      if (nickname.length < 5)
+        return { message: '닉네임은 5자 이상이어야 합니다.' };
+      if (!regexUsername.test(nickname))
+        return {
+          message: '닉네임은 영문소문자, 숫자, 특수기호(_)만 사용 가능합니다.',
+        };
+      const response = await apiCheckNickname(nickname);
+      return response.data.isUnique
+        ? { message: '사용 가능한 닉네임입니다.' }
+        : { message: '이미 사용 중인 닉네임입니다.' };
+    },
+    [isInputFocused.nickname]
+  );
 
   const checkFormValidity = useCallback(() => {
     return (
@@ -179,7 +238,37 @@ function RegisterPage() {
     );
   }, [registerInfo, registerHelper, isAgreementChecked]);
 
+  const updateUsernameHelper = useCallback(
+    async (username: string) => {
+      const usernameHelper = await getUsernameHelper(username);
+      setRegisterHelper((prev) => ({
+        ...prev,
+        username: usernameHelper.message,
+      }));
+    },
+    [getUsernameHelper]
+  );
+
+  const updateNicknameHelper = useCallback(
+    async (nickname: string) => {
+      const nicknameHelper = await getNicknameHelper(nickname);
+      setRegisterHelper((prev) => ({
+        ...prev,
+        nickname: nicknameHelper.message,
+      }));
+    },
+    [getNicknameHelper]
+  );
+
   useEffect(() => {
+    updateUsernameHelper(registerInfo.username);
+  }, [registerInfo.username, updateUsernameHelper]);
+
+  useEffect(() => {
+    setRegisterHelper((prev) => ({
+      ...prev,
+      password: getPasswordHelper(registerInfo.password).message,
+    }));
     setRegisterHelper((prev) => ({
       ...prev,
       passwordConfirm: getPasswordConfirmHelper(registerInfo.passwordConfirm)
@@ -188,8 +277,13 @@ function RegisterPage() {
   }, [
     registerInfo.password,
     registerInfo.passwordConfirm,
+    getPasswordHelper,
     getPasswordConfirmHelper,
   ]);
+
+  useEffect(() => {
+    updateNicknameHelper(registerInfo.nickname);
+  }, [registerInfo.nickname, updateNicknameHelper]);
 
   useEffect(() => {
     setIsRegisterButtonDisabled(!checkFormValidity());
@@ -206,9 +300,13 @@ function RegisterPage() {
       <RegisterPageLayout
         onChangeInput={onChangeInput}
         onChangeCheckbox={onChangeCheckbox}
+        onFocusInput={onFocusInput}
+        onClickClear={onClickClear}
+        onClickTogglePassword={onClickTogglePassword}
         onClickRegister={onClickRegister}
         registerInfo={registerInfo}
         registerHelper={registerHelper}
+        isInputHidden={isInputHidden}
         isAgreementChecked={isAgreementChecked}
         isRegisterButtonDisabled={isRegisterButtonDisabled}
       />

--- a/src/components/Register/index.tsx
+++ b/src/components/Register/index.tsx
@@ -50,7 +50,7 @@ function RegisterPage() {
   const [isRegisterButtonDisabled, setIsRegisterButtonDisabled] =
     useState<boolean>(true);
 
-  const onChangeInput = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setRegisterInfo({
       ...registerInfo,
@@ -58,7 +58,7 @@ function RegisterPage() {
     });
   };
 
-  const onChangeCheckbox = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
     switch (id) {
       case 'agreementAll':

--- a/src/components/Register/registerPage.module.scss
+++ b/src/components/Register/registerPage.module.scss
@@ -35,200 +35,107 @@
       .joinForm {
         width: 345px;
         background-color: white;
-        .inputIdArea {
-          width: 345px;
-          height: 79px;
-          background-color: white;
-          .inputIdLabel {
-            height: 21px;
-            width: 48px;
-            margin-bottom: 8px;
+        .inputArea {
+          margin-top: 8px;
+          font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR',
+            helvetica, Gulim, sans-serif;
+          line-height: 21px;
+          font-size: 14px;
+          height: 110px;
+          .inputLabel {
             display: inline-block;
-            line-height: 21px;
-            font-size: 14px;
-            font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR',
-              helvetica, Gulim, sans-serif;
-            .inputIdDot {
+            margin: 16px 0 8px;
+            .inputDot {
               display: inline-block;
+              overflow: hidden;
+              margin-left: 4px;
               width: 4px;
               height: 4px;
               margin-top: 4px;
               border-radius: 50%;
               background-color: red;
               vertical-align: top;
-              position: relative;
-              left: 3px;
             }
           }
-          .inputIdWrap {
-            width: 345px;
+          .inputWrap {
+            display: flex;
+            box-sizing: border-box;
             height: 50px;
             border: 1px solid #e5e5e5;
             border-radius: 4px;
-            box-sizing: border-box;
-            background-color: white;
-            .inputId {
+            justify-content: space-between;
+            align-items: center;
+            .input {
               width: 100%;
               height: 48px;
-              box-sizing: border-box;
               padding: 0 12px;
-              border: 0px;
-            }
-            .IdCheckT {
-              color: blue;
-            }
-            .IdCheckF {
-              color: red;
-            }
-          }
-        }
-        .inputPasswordArea {
-          margin-top: 8px;
-          width: 100%;
-          height: 95px;
-          background-color: white;
-          .inputPasswordLabel {
-            height: 21px;
-            margin-top: 16px;
-            margin-bottom: 8px;
-            display: inline-block;
-            line-height: 21px;
-            font-size: 14px;
-            font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR',
-              helvetica, Gulim, sans-serif;
-            .inputPasswordDot {
-              display: inline-block;
-              width: 4px;
-              height: 4px;
-              margin-top: 4px;
-              border-radius: 50%;
-              background-color: red;
-              vertical-align: top;
-              position: relative;
-              left: 3px;
-            }
-          }
-          .inputPasswordWrap {
-            width: 100%;
-            height: 50px;
-            box-sizing: border-box;
-            border: 1px solid #e5e5e5;
-            border-radius: 4px;
-            background-color: white;
-            .inputPassword {
+              border: none;
+              flex: 0 1 auto;
+              background-color: #fff;
+              font-size: 15px;
+              font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR', helvetica, Gulim, sans-serif;
+              color: #000;
+              box-shadow: 0 0 0 30px #fff inset!important;
+              transition: border .2s ease-in-out;
+              appearance: none;
               box-sizing: border-box;
-              width: 100%;
-              height: 48px;
-              padding: 0 12px 0 12px;
-              border: 0px;
+              vertical-align: middle;
+              outline: 0;
+              margin: 0 1px;
             }
+            .inputClearButton {
+              display: flex;
+              margin-right: 7px;
+              padding: 5px;
+              flex: 0 0 auto;
+              appearance: none;
+              border: none;
+              background: 0 0;
+              cursor: pointer;
+            }
+            .showPasswordButton {
+              display: flex;
+              background: url(https://static.msscdn.net/ui/build/m/img/login/ic-30-show-button.svg?v=20230119143941) no-repeat 50% 50%;
+              margin-right: 7px;
+              padding: 0;
+              width: 30px;
+              height: 30px;
+              flex: 0 0 auto;
+              border: none;
+              cursor: pointer;
+            }
+            .hidePasswordButton {
+              display: flex;
+              background: url(https://static.msscdn.net/ui/build/m/img/login/ic-30-hide-button.svg?v=20230119143941) no-repeat 50% 50%;
+              margin-right: 7px;
+              padding: 0;
+              width: 30px;
+              height: 30px;
+              flex: 0 0 auto;
+              border: none;
+              cursor: pointer;
+            }
+          }
+          .inputWrapDanger {
+            border-color: red!important;
+          }
+          .helper {
+            font-size: 12px;
+            margin-top: 1px;
+            margin-left: 2px;
+          }
+          .valid {
+            color: blue;
+          }
+          .invalid {
+            color: red;
           }
         }
-        .inputPasswordMessage {
-          width: 100%;
-          height: 16.5px;
-          margin-top: 8px;
-          position: static;
-          color: red;
+        .inputAreaFirst {
+          margin-top: 0;
         }
-        .inputRepeatArea {
-          width: 100%;
-          height: 50px;
-          margin-top: 8px;
-          background-color: white;
-          .inputRepeatWrap {
-            width: 100%;
-            height: 50px;
-            box-sizing: border-box;
-            border: 1px solid #e5e5e5;
-            border-radius: 4px;
-            .inputRepeat {
-              width: 100%;
-              height: 48px;
-              box-sizing: border-box;
-              border: 0px;
-              padding: 0 12px 0 12px;
-            }
-            .inputRepeatMessage {
-              color: red;
-            }
-          }
-        }
-        .inputNickArea {
-          height: 119.5px;
-          margin-top: 8px;
-          background-color: white;
-          width: 100%;
-          .inputNickLabel {
-            height: 21px;
-            margin-top: 16px;
-            margin-bottom: 8px;
-            display: inline-block;
-            line-height: 21px;
-            font-size: 14px;
-            font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR',
-              helvetica, Gulim, sans-serif;
-            .inputNickDot {
-              display: inline-block;
-              width: 4px;
-              height: 4px;
-              margin-top: 4px;
-              border-radius: 50%;
-              background-color: red;
-              vertical-align: top;
-              position: relative;
-              left: 3px;
-            }
-          }
-          .inputNickWrap {
-            width: 100%;
-            height: 50px;
-            box-sizing: border-box;
-            border-radius: 4px;
-            .inputNick {
-              width: 100%;
-              height: 48px;
-              box-sizing: border-box;
-              border: 1px solid #e5e5e5;
-              padding: 0 12px 0 12px;
-            }
-            .validNickname {
-              color: blue;
-            }
-            .invalidNickname {
-              color: red;
-            }
-          }
-        }
-        .inputRecommendIdArea {
-          height: 95px;
-          margin-top: 8px;
-          background-color: white;
-          width: 100%;
-          .inputRecommendIdLabel {
-            height: 21px;
-            margin-top: 16px;
-            margin-bottom: 8px;
-            display: inline-block;
-            line-height: 21px;
-            font-size: 14px;
-            font-family: '-apple-system', HelveticaNeue, Roboto, 'Noto Sans KR',
-              helvetica, Gulim, sans-serif;
-          }
-          .inputRecommendIdWrap {
-            width: 100%;
-            height: 50px;
-            box-sizing: border-box;
-            border: 1px solid #e5e5e5;
-            border-radius: 4px;
-            .inputRecommendId {
-              width: 100%;
-              height: 48px;
-              box-sizing: border-box;
-              border: 0px;
-              padding: 0 12px 0 12px;
-            }
-          }
+        .inputAreaPasswordConfirm {
+          height: 79px
         }
         .agreementForm {
           width: 100%;

--- a/src/components/Register/registerPage.module.scss
+++ b/src/components/Register/registerPage.module.scss
@@ -125,7 +125,7 @@
             margin-left: 2px;
           }
           .valid {
-            color: blue;
+            color: #14aaff;
           }
           .invalid {
             color: red;

--- a/src/components/Register/registerPage.tsx
+++ b/src/components/Register/registerPage.tsx
@@ -249,6 +249,7 @@ export default function RegisterPageLayout({
                     id="inputNick"
                     name="nickname"
                     placeholder="영문, 숫자 5-11자"
+                    maxLength={11}
                     onFocus={() => {
                       onFocusInput('nickname');
                     }}

--- a/src/components/Register/registerPage.tsx
+++ b/src/components/Register/registerPage.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import styles from './registerPage.module.scss';
 
 interface RegisterPageProps {
-  onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => {};
+  onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
   onChangeCheckbox: (e: React.ChangeEvent<HTMLInputElement>) => {};
+  onFocusInput: (input: string) => void;
+  onClickClear: (input: string) => void;
+  onClickTogglePassword: (input: string) => void;
   onClickRegister: () => void;
   registerInfo: RegisterInfo;
   registerHelper: RegisterInfo;
+  isInputHidden: { password: boolean; passwordConfirm: boolean };
   isAgreementChecked: IsAgreementChecked;
   isRegisterButtonDisabled: boolean;
 }
@@ -29,9 +33,13 @@ export interface IsAgreementChecked {
 export default function RegisterPageLayout({
   onChangeInput,
   onChangeCheckbox,
+  onFocusInput,
+  onClickClear,
+  onClickTogglePassword,
   onClickRegister,
   registerInfo,
   registerHelper,
+  isInputHidden,
   isAgreementChecked,
   isRegisterButtonDisabled,
 }: RegisterPageProps) {
@@ -52,104 +60,229 @@ export default function RegisterPageLayout({
         <div className={styles.contentArea}>
           <div className={styles.joinContainer}>
             <div className={styles.joinForm}>
-              <div className={styles.inputIdArea}>
-                <label className={styles.inputIdLabel} htmlFor="inputId">
+              <div className={`${styles.inputArea} ${styles.inputAreaFirst}`}>
+                <label className={styles.inputLabel} htmlFor="inputId">
                   아이디
-                  <span className={styles.inputIdDot}></span>
+                  <span className={styles.inputDot}></span>
                 </label>
-                <div className={styles.inputIdWrap}>
+                <div
+                  className={
+                    registerHelper.username &&
+                    registerHelper.username !== '사용 가능한 아이디입니다.'
+                      ? `${styles.inputWrap} ${styles.inputWrapDanger}`
+                      : styles.inputWrap
+                  }
+                >
                   <input
-                    className={styles.inputId}
+                    className={styles.input}
                     name="username"
                     value={username}
                     placeholder="영문, 숫자 5-11자"
                     type="text"
                     maxLength={11}
                     id="inputId"
+                    onFocus={() => {
+                      onFocusInput('username');
+                    }}
                     onChange={(e) => {
                       onChangeInput(e);
                     }}
                   ></input>
-                  <div
-                    className={
-                      registerHelper.username === '사용 가능한 아이디입니다.'
-                        ? styles.IdCheckT
-                        : styles.IdCheckF
-                    }
-                  >
-                    {registerHelper.username}
-                  </div>
+                  {username && (
+                    <button
+                      className={styles.inputClearButton}
+                      type="button"
+                      onClick={() => onClickClear('username')}
+                    >
+                      <svg width={20} height={20} fill="none">
+                        <circle cx="10" cy="10" r="10" fill="#B3B3B3"></circle>
+                        <path
+                          d="M5.52786 5.52742L14.4722 14.4718M14.4722 5.52734L5.52783 14.4717"
+                          stroke="white"
+                        ></path>
+                      </svg>
+                    </button>
+                  )}
+                </div>
+                <div
+                  className={
+                    registerHelper.username === '사용 가능한 아이디입니다.'
+                      ? `${styles.helper} ${styles.valid}`
+                      : `${styles.helper} ${styles.invalid}`
+                  }
+                >
+                  {registerHelper.username}
                 </div>
               </div>
-              <div className={styles.inputPasswordArea}>
-                <label
-                  className={styles.inputPasswordLabel}
-                  htmlFor="inputPassword"
-                >
+
+              <div className={styles.inputArea}>
+                <label className={styles.inputLabel} htmlFor="inputPassword">
                   비밀번호
-                  <span className={styles.inputPasswordDot}></span>
+                  <span className={styles.inputDot}></span>
                 </label>
-                <div className={styles.inputPasswordWrap}>
+                <div
+                  className={
+                    registerHelper.password
+                      ? `${styles.inputWrap} ${styles.inputWrapDanger}`
+                      : styles.inputWrap
+                  }
+                >
                   <input
-                    className={styles.inputPassword}
+                    className={styles.input}
                     name="password"
                     value={password}
                     placeholder="숫자, 영문, 특수문자 조합 최소 8자"
-                    type="password"
+                    type={isInputHidden.password ? 'password' : 'text'}
                     maxLength={30}
                     id="inputPassword"
+                    onFocus={() => {
+                      onFocusInput('password');
+                    }}
                     onChange={(e) => {
                       onChangeInput(e);
                     }}
                   ></input>
+                  {password && (
+                    <button
+                      className={styles.inputClearButton}
+                      type="button"
+                      onClick={() => onClickClear('password')}
+                    >
+                      <svg width={20} height={20} fill="none">
+                        <circle cx="10" cy="10" r="10" fill="#B3B3B3"></circle>
+                        <path
+                          d="M5.52786 5.52742L14.4722 14.4718M14.4722 5.52734L5.52783 14.4717"
+                          stroke="white"
+                        ></path>
+                      </svg>
+                    </button>
+                  )}
+                  {password && (
+                    <button
+                      className={
+                        isInputHidden.password
+                          ? styles.showPasswordButton
+                          : styles.hidePasswordButton
+                      }
+                      onClick={(e) => {
+                        onClickTogglePassword('password');
+                      }}
+                    ></button>
+                  )}
+                </div>
+                <div className={`${styles.helper} ${styles.invalid}`}>
+                  {registerHelper.password}
                 </div>
               </div>
-              <div className={styles.inputPasswordMessage}>
-                {registerHelper.password}
-              </div>
-              <div className={styles.inputRepeatArea}>
-                <div className={styles.inputRepeatWrap}>
+
+              <div
+                className={`${styles.inputArea} ${styles.inputAreaPasswordConfirm}`}
+              >
+                <div
+                  className={
+                    registerHelper.passwordConfirm
+                      ? `${styles.inputWrap} ${styles.inputWrapDanger}`
+                      : styles.inputWrap
+                  }
+                >
                   <input
-                    className={styles.inputRepeat}
+                    className={styles.input}
                     name="passwordConfirm"
                     value={passwordConfirm}
                     placeholder="비밀번호 재입력"
-                    type="password"
-                    onChange={(e) => {
+                    type={isInputHidden.passwordConfirm ? 'password' : 'text'}
+                    onFocus={() => {
+                      onFocusInput('passwordConfirm');
+                    }}
+                    onChange={async (e) => {
                       onChangeInput(e);
                     }}
                   ></input>
-                  <div className={styles.inputRepeatMessage}>
-                    {registerHelper.passwordConfirm}
-                  </div>
+                  {passwordConfirm && (
+                    <button
+                      className={styles.inputClearButton}
+                      type="button"
+                      onClick={() => onClickClear('passwordConfirm')}
+                    >
+                      <svg width={20} height={20} fill="none">
+                        <circle cx="10" cy="10" r="10" fill="#B3B3B3"></circle>
+                        <path
+                          d="M5.52786 5.52742L14.4722 14.4718M14.4722 5.52734L5.52783 14.4717"
+                          stroke="white"
+                        ></path>
+                      </svg>
+                    </button>
+                  )}
+                  {passwordConfirm && (
+                    <button
+                      className={
+                        isInputHidden.passwordConfirm
+                          ? styles.showPasswordButton
+                          : styles.hidePasswordButton
+                      }
+                      onClick={(e) => {
+                        onClickTogglePassword('passwordConfirm');
+                      }}
+                    ></button>
+                  )}
+                </div>
+                <div className={`${styles.helper} ${styles.invalid}`}>
+                  {registerHelper.passwordConfirm}
                 </div>
               </div>
-              <div className={styles.inputNickArea}>
-                <label className={styles.inputNickLabel} htmlFor="inputNick">
+
+              <div className={styles.inputArea}>
+                <label className={styles.inputLabel} htmlFor="inputNick">
                   닉네임
-                  <span className={styles.inputNickDot}></span>
+                  <span className={styles.inputDot}></span>
                 </label>
-                <div className={styles.inputNickWrap}>
+                <div
+                  className={
+                    registerHelper.nickname &&
+                    registerHelper.nickname !== '사용 가능한 닉네임입니다.'
+                      ? `${styles.inputWrap} ${styles.inputWrapDanger}`
+                      : styles.inputWrap
+                  }
+                >
                   <input
-                    className={styles.inputNick}
+                    className={styles.input}
                     id="inputNick"
                     name="nickname"
-                    value={nickname}
-                    onChange={(e) => {
-                      onChangeInput(e);
+                    placeholder="영문, 숫자 5-11자"
+                    onFocus={() => {
+                      onFocusInput('nickname');
+                    }}
+                    onChange={async (e) => {
+                      await onChangeInput(e);
                     }}
                   ></input>
-                  <div
-                    className={
-                      registerHelper.nickname === '사용 가능한 닉네임입니다.'
-                        ? styles.validNickname
-                        : styles.invalidNickname
-                    }
-                  >
-                    {registerHelper.nickname}
-                  </div>
+                  {nickname && (
+                    <button
+                      className={styles.inputClearButton}
+                      type="button"
+                      onClick={() => onClickClear('nickname')}
+                    >
+                      <svg width={20} height={20} fill="none">
+                        <circle cx="10" cy="10" r="10" fill="#B3B3B3"></circle>
+                        <path
+                          d="M5.52786 5.52742L14.4722 14.4718M14.4722 5.52734L5.52783 14.4717"
+                          stroke="white"
+                        ></path>
+                      </svg>
+                    </button>
+                  )}
+                </div>
+                <div
+                  className={
+                    registerHelper.nickname === '사용 가능한 닉네임입니다.'
+                      ? `${styles.helper} ${styles.valid}`
+                      : `${styles.helper} ${styles.invalid}`
+                  }
+                >
+                  {registerHelper.nickname}
                 </div>
               </div>
+
               {/* <div className={styles.inputRecommendIdArea}>
                 <label className={styles.inputRecommendIdLabel}>
                   친구 초대 추천인 아이디

--- a/src/components/Register/registerPage.tsx
+++ b/src/components/Register/registerPage.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styles from './registerPage.module.scss';
 
 interface RegisterPageProps {
-  onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
-  onChangeCheckbox: (e: React.ChangeEvent<HTMLInputElement>) => {};
+  onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeCheckbox: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onFocusInput: (input: string) => void;
   onClickClear: (input: string) => void;
   onClickTogglePassword: (input: string) => void;
@@ -194,7 +194,7 @@ export default function RegisterPageLayout({
                     onFocus={() => {
                       onFocusInput('passwordConfirm');
                     }}
-                    onChange={async (e) => {
+                    onChange={(e) => {
                       onChangeInput(e);
                     }}
                   ></input>
@@ -252,8 +252,8 @@ export default function RegisterPageLayout({
                     onFocus={() => {
                       onFocusInput('nickname');
                     }}
-                    onChange={async (e) => {
-                      await onChangeInput(e);
+                    onChange={(e) => {
+                      onChangeInput(e);
                     }}
                   ></input>
                   {nickname && (

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,20 +1,17 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
-import { sessionActions } from '../../store/slices/session';
+import { useNavigate } from 'react-router-dom';
+import { AppDispatch } from '../../store';
+import { postRefresh } from '../../store/slices/session';
 
 export default function SocialLoginPage() {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const { accessToken } = useParams<{ accessToken: string }>();
+  const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
-    if (accessToken) {
-      console.log(accessToken);
-      dispatch(sessionActions.setAccessToken(accessToken));
-      navigate('/');
-    }
-  }, [accessToken, dispatch, navigate]);
+    dispatch(postRefresh());
+    navigate('/');
+  }, [dispatch, navigate]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,17 +1,19 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { AppDispatch } from '../../store';
 import { postRefresh } from '../../store/slices/session';
 
 export default function SocialLoginPage() {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
+  const { accessToken } = useParams();
 
   useEffect(() => {
     dispatch(postRefresh());
     // navigate('/');
-  }, [dispatch, navigate]);
+    console.log(accessToken);
+  }, [dispatch, navigate, accessToken]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,19 +1,18 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
-import { AppDispatch } from '../../store';
-import { postRefresh } from '../../store/slices/session';
+// import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+// import { AppDispatch } from '../../store';
 
 export default function SocialLoginPage() {
-  const navigate = useNavigate();
-  const dispatch = useDispatch<AppDispatch>();
+  // const navigate = useNavigate();
+  // const dispatch = useDispatch<AppDispatch>();
   const { accessToken } = useParams();
 
   useEffect(() => {
-    dispatch(postRefresh());
+    // dispatch(postRefresh());
     // navigate('/');
     console.log(accessToken);
-  }, [dispatch, navigate, accessToken]);
+  }, [accessToken]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -2,19 +2,22 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { AppDispatch } from '../../store';
-import { postRefresh } from '../../store/slices/session';
+// import { postRefresh } from '../../store/slices/session';
 // import { AppDispatch } from '../../store';
+import { useCookies } from 'react-cookie';
 
 export default function SocialLoginPage() {
   // const navigate = useNavigate();
+  const [cookies, setCookie] = useCookies(['refreshToken']);
   const dispatch = useDispatch<AppDispatch>();
   const { accessToken } = useParams();
 
   useEffect(() => {
-    dispatch(postRefresh());
     // navigate('/');
-    console.log(accessToken);
-  }, [accessToken, dispatch]);
+    setCookie('refreshToken', accessToken!);
+    console.log(cookies);
+    // dispatch(postRefresh());
+  }, [accessToken, cookies, dispatch, setCookie]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,18 +1,20 @@
 import { useEffect } from 'react';
-// import { useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { AppDispatch } from '../../store';
+import { postRefresh } from '../../store/slices/session';
 // import { AppDispatch } from '../../store';
 
 export default function SocialLoginPage() {
   // const navigate = useNavigate();
-  // const dispatch = useDispatch<AppDispatch>();
+  const dispatch = useDispatch<AppDispatch>();
   const { accessToken } = useParams();
 
   useEffect(() => {
-    // dispatch(postRefresh());
+    dispatch(postRefresh());
     // navigate('/');
     console.log(accessToken);
-  }, [accessToken]);
+  }, [accessToken, dispatch]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,11 +1,17 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { sessionActions } from '../../store/slices/session';
 
 export default function SocialLoginPage() {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { accessToken } = useParams<{ accessToken: string }>();
+
   useEffect(() => {
-    navigate(-2);
-  }, [navigate]);
+    dispatch(sessionActions.setAccessToken(accessToken!));
+    navigate('/');
+  }, [accessToken, dispatch, navigate]);
 
   return <></>;
 }

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -9,8 +9,11 @@ export default function SocialLoginPage() {
   const { accessToken } = useParams<{ accessToken: string }>();
 
   useEffect(() => {
-    dispatch(sessionActions.setAccessToken(accessToken!));
-    navigate('/');
+    if (accessToken) {
+      console.log(accessToken);
+      dispatch(sessionActions.setAccessToken(accessToken));
+      navigate('/');
+    }
   }, [accessToken, dispatch, navigate]);
 
   return <></>;

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -10,7 +10,7 @@ export default function SocialLoginPage() {
 
   useEffect(() => {
     dispatch(postRefresh());
-    navigate('/');
+    // navigate('/');
   }, [dispatch, navigate]);
 
   return <></>;

--- a/src/components/SocialLoginPage/index.tsx
+++ b/src/components/SocialLoginPage/index.tsx
@@ -1,23 +1,27 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { apiSocialLogin } from '../../lib/api';
 import { AppDispatch } from '../../store';
-// import { postRefresh } from '../../store/slices/session';
-// import { AppDispatch } from '../../store';
-import { useCookies } from 'react-cookie';
+import { postRefresh } from '../../store/slices/session';
 
 export default function SocialLoginPage() {
-  // const navigate = useNavigate();
-  const [cookies, setCookie] = useCookies(['refreshToken']);
+  const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const { accessToken } = useParams();
 
+  const socialLogin = useCallback(
+    async (accessToken: string) => {
+      await apiSocialLogin(accessToken);
+      await dispatch(postRefresh());
+      navigate('/');
+    },
+    [navigate, dispatch]
+  );
+
   useEffect(() => {
-    // navigate('/');
-    setCookie('refreshToken', accessToken!);
-    console.log(cookies);
-    // dispatch(postRefresh());
-  }, [accessToken, cookies, dispatch, setCookie]);
+    if (accessToken) socialLogin(accessToken);
+  }, [accessToken, socialLogin]);
 
   return <></>;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,9 @@ export const apiLogin = (username: string, password: string) =>
     password,
   });
 
+export const apiSocialLogin = (token: string) =>
+  axios.post('/api/auth/social-login', null, { headers: auth(token) });
+
 export const apiLogout = (token: string) =>
   axios.post('/api/auth/logout', null, { headers: auth(token) });
 

--- a/src/store/slices/session.ts
+++ b/src/store/slices/session.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { apiLogin, apiLogout, apiRefresh, apiGetMyInfo } from '../../lib/api';
 import { LoginDto } from '../../lib/dto';
 import { Session } from '../../lib/interface';
@@ -48,7 +48,11 @@ export const postRefresh = createAsyncThunk<Session>(
 export const sessionSlice = createSlice({
   name: 'session',
   initialState,
-  reducers: {},
+  reducers: {
+    setAccessToken: (state, action: PayloadAction<string>) => {
+      state.accessToken = action.payload;
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(postLogin.fulfilled, (state, action) => {
       state.user = action.payload.user;
@@ -69,4 +73,5 @@ export const sessionSlice = createSlice({
   },
 });
 
+export const sessionActions = sessionSlice.actions;
 export default sessionSlice;


### PR DESCRIPTION
회원가입 페이지를 더 완성도 있게 만들면 좋을 것 같아서 몇 가지 수정했습니다.
로컬에서 따로 돌려보실 필요 없이 Netlify의 Deploy Preview에서 직접 확인하실 수 있습니다. 다음 개선 사항 중에 제대로 동작하지 않는 부분이 있으면 알려주세요!

### CSS 수정
- .scss 파일에서 불필요하게 반복되는 코드를 제거하였습니다.
  - input마다 분리되어 있던 css를 하나로 통일
- (굵은 파란색 선으로 표시되던) input의 outline을 삭제하였습니다.
- Valid한 input에 대해 표시되는 helper text의 글자색을 기존의 파란색에서 무신사와 동일한 `#14aaff`로 수정하였습니다.
- 기존 무신사와 동일하게 유효하지 않은 input의 경우 (무신사와 마찬가지로) input 박스의 테두리가 빨간색으로 표시됩니다.
  - valid한 input을 입력하면 테두리가 원래대로 돌아갑니다.

### input 삭제 버튼 추가
- 기존 무신사에 존재하는 input 삭제 버튼을 추가하였습니다.
- Input에 한 글자라도 들어오면 버튼이 표시됩니다.
- 버튼을 누르면 input을 한 번에 지울 수 있습니다.
- Helper text도 잘 동작합니다.

### password toggle 버튼 추가
- 기존 무신사에 존재하는 password toggle 버튼을 추가하였습니다.
- Input에 한 글자라도 들어오면 버튼이 표시됩니다.
- 버튼을 누르면 `비밀번호` 및 `비밀번호 재입력` input이 각각 공개/비공개 됩니다.

### 중복 확인 API 호출 관련 버그 개선
- 승진 님께서 저번 PR에 언급해주신 "아이디&닉네임 작성 후 백스페이스로 비웠을때 사용가능한 아이디로 뜨는 현상"을 개선했습니다.
- Key stroke마다 API를 호출하기 때문에 빠른 속도로 input을 작성했다 지우면 helper text가 제대로 표시되지 않는 현상이 발생하는 버그가 있었습니다. 특히 글자 수 제한이 없는 `닉네임` input에서 버그를 쉽게 발견할 수 있었습니다.
- 이를 개선하고자 `닉네임` 작성 시에도 `아이디`와 동일한 정규표현식을 적용하여 input 길이가 5 이상일 때에만 API 호출이 되게끔 제한을 두었습니다.
- 또한 기존의 모호한 비동기 `useState` 처리 구문을 `useEffect`와 `useCallBack`을 사용하여 개선하였습니다.
- 로컬에선 버그가 발생하지 않지만, 배포 사이트에서 시도해 보니 종종 발생하긴 하네요... 배포 사이트의 API 호출이 워낙 느리다 보니 어쩔 수 없는 것 같습니다 ㅜㅜ 개선 방안 있으시면 바로 말씀해주세요.