### PR TITLE
fix: navigate after axiosresponse

### DIFF
--- a/src/components/MyPage/MyPageWriteReviews/index.tsx
+++ b/src/components/MyPage/MyPageWriteReviews/index.tsx
@@ -99,8 +99,7 @@ export default function MyPageWriteReviews({
         input.color,
         secureImages,
         accessToken
-      );
-      navigate(-1);
+      ).then((response) => navigate(-1));
     } else {
       apiPostReview(
         data.id,
@@ -110,8 +109,7 @@ export default function MyPageWriteReviews({
         input.color,
         [],
         accessToken
-      );
-      navigate(-1);
+      ).then((response) => navigate(-1));
     }
     // TODO: 이미지 업로드 후 return된 secureImages를 request body에 포함하여 게시글 POST
     // await axios.post('게시글 관련 API', {..., secureImages})


### PR DESCRIPTION
회의한 날 새벽에 찬혁님과 직접 백엔드 연결해보다가 발생한 오류를 수정하였습니다. post api/user/me/reviews를 날리고 나서 navigate되면 바로 get api/user/me/purchase를 했더니 isReviewed가 반영이 안되는 오류가 있었습니다. 그래서 post한 후 axiosresponse가 들어오면 navigate하는 것으로 수정하여 오류를 고쳤습니다. 오류 수정 후 잘 작동되는 것 까지 다 확인하였습니다! 