### PR TITLE
Fix : bug

### DIFF
--- a/src/components/Closet/ClosetHeader/ClosetHeader.module.scss
+++ b/src/components/Closet/ClosetHeader/ClosetHeader.module.scss
@@ -2,7 +2,6 @@
   background-color: black;
   color: white;
   padding: 0px 40px 80px 40px;
-  position: relative;
 }
 
 .title {
@@ -16,6 +15,15 @@
   text-decoration: none;
 }
 
+.titleNotMe {
+  color: inherit;
+  display: inline-block;
+  font-family: Musinsa, 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+  font-size: 24px;
+  line-height: 52px;
+  padding: 20px 0 24px;
+  text-decoration: none;
+}
 .nav {
   padding-right: 40px;
   position: absolute;
@@ -39,8 +47,9 @@
 }
 
 .main {
-  overflow: hidden;
+  display: flex;
   padding-left: 40px;
+  position: relative;
 }
 
 .image {
@@ -71,11 +80,6 @@
   }
 }
 
-// .flex {
-//   align-items: center;
-//   display: flex;
-// }
-
 .userprofile {
   padding: 10px 0px;
 }
@@ -88,7 +92,6 @@
 }
 
 .userrate {
-  // border: 1px solid red;
   padding: 0px 50px;
   width: 300px;
   display: flex;
@@ -100,12 +103,12 @@
   .modal {
     border: 1px solid #e5e5e5;
     position: absolute;
-    bottom: -180px;
+    bottom: -260px;
     width: 230px;
     height: 300px;
     background-color: rgb(250, 250, 250);
     z-index: 999;
-    padding: 0px 10px;
+    padding: 0px 18px;
     overflow: auto;
     .modalTitle {
       padding: 10px 5px;

--- a/src/components/Closet/ClosetHeader/index.tsx
+++ b/src/components/Closet/ClosetHeader/index.tsx
@@ -123,7 +123,19 @@ export default function ClosetHeader({
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.title}>My Closet</div>
+      {isMe ? (
+        <div
+          className={styles.title}
+          onClick={() => {
+            navigate('/closet/my');
+          }}
+        >
+          My Closet
+        </div>
+      ) : (
+        <div className={styles.titleNotMe}>Closet</div>
+      )}
+
       {user && (
         <div className={styles.main}>
           <img className={styles.image} src={user?.image} alt="이미지 없음" />

--- a/src/components/Header/HeaderLayout.tsx
+++ b/src/components/Header/HeaderLayout.tsx
@@ -37,7 +37,7 @@ function GnbList({ user, onLogout }: GnbListProps) {
           </li>
           <li>
             <Link className={styles.gnb_element} to="/mypage/order">
-              주문배송조회
+              주문내역조회
             </Link>
           </li>
           <li>

--- a/src/components/MyPage/MyPageHeader/index.tsx
+++ b/src/components/MyPage/MyPageHeader/index.tsx
@@ -16,14 +16,6 @@ export default function MyPageHeader({ user, onLogout }: MyPageHeaderProps) {
       <Link className={styles.title} to="/mypage">
         My Page
       </Link>
-      <div className={styles.nav}>
-        <Link className={styles.nav_link} to="/cart">
-          장바구니
-        </Link>
-        <button className={styles.nav_link} onClick={onLogout}>
-          로그아웃
-        </button>
-      </div>
       <div className={styles.main}>
         <img className={styles.image} src={user.image} alt="이미지 없음" />
         <div className={styles.info}>

--- a/src/components/MyPage/MyPageNavigation/index.tsx
+++ b/src/components/MyPage/MyPageNavigation/index.tsx
@@ -16,9 +16,6 @@ export default function MyPageNavigation() {
         <Link className={styles.nav} to="/mypage/item_inquiry">
           상품문의
         </Link>
-        <Link className={styles.nav} to="/mypage/personal_inquiry">
-          1:1문의
-        </Link>
         <Link className={styles.nav} to="/mypage/viewed_goods">
           최근 본 상품
         </Link>

--- a/src/components/MyPage/MyPageOrder/ItemOrdered.module.scss
+++ b/src/components/MyPage/MyPageOrder/ItemOrdered.module.scss
@@ -26,6 +26,7 @@
       height: 100%;
       margin: auto;
       display: block;
+      cursor: pointer;
     }
   }
   .ItemInfo {

--- a/src/components/MyPage/MyPageOrder/ItemOrdered.tsx
+++ b/src/components/MyPage/MyPageOrder/ItemOrdered.tsx
@@ -1,5 +1,6 @@
 import styles from './ItemOrdered.module.scss';
 import { Purchase } from '../../../lib/interface';
+import { useNavigate } from 'react-router-dom';
 
 interface ItemOrderedProps {
   purchase: Purchase;
@@ -10,6 +11,8 @@ export default function ItemOrdered({
   purchase,
   formatDate,
 }: ItemOrderedProps) {
+  const navigate = useNavigate();
+
   return (
     <div className={styles.grid_order}>
       <div className={styles.grid_header}>
@@ -19,6 +22,9 @@ export default function ItemOrdered({
               className={styles.previewImage}
               src={purchase.item.images[0]}
               alt="상품 이미지"
+              onClick={() => {
+                navigate(`/goods/${purchase.item.id}`);
+              }}
             />
           </div>
           <div className={styles.ItemInfo}>
@@ -29,7 +35,7 @@ export default function ItemOrdered({
               <span className={styles.name}>{purchase.item.name}</span>
             </div>
             <div className={styles.InfoLine}>
-              <span className={styles.size}>M</span>
+              <span className={styles.size}>{purchase.option}</span>
             </div>
           </div>
         </div>
@@ -39,16 +45,11 @@ export default function ItemOrdered({
       </div>
       <div className={styles.grid_header}>{purchase.id}</div>
       <div className={styles.grid_header}>
-        {purchase.payment?.toLocaleString()} 원
+        {purchase.payment?.toLocaleString()}원 ({purchase.quantity}개)
       </div>
       <div className={styles.grid_header}>
         <div className={styles.orderState}>
-          <div className={styles.stateDiv}>입금확인</div>
-          <div className={styles.buttonDiv}>
-            <button>환불 요청</button>
-            <button>교환 요청</button>
-            <button>배송지 변경</button>
-          </div>
+          <div className={styles.stateDiv}>구매확정</div>
         </div>
       </div>
     </div>

--- a/src/components/MyPage/MyPageOrder/MyPageOrder.module.scss
+++ b/src/components/MyPage/MyPageOrder/MyPageOrder.module.scss
@@ -4,6 +4,7 @@
   margin-top: -32px;
   padding-right: 40px;
   width: calc(100% - 290px);
+  min-height: calc(100vh - 500px);
 }
 
 .title {

--- a/src/components/MyPage/MyPageOrder/index.tsx
+++ b/src/components/MyPage/MyPageOrder/index.tsx
@@ -18,20 +18,6 @@ export default function MyPageOrder({
       <section id="order">
         <header className={styles.title}>
           <h2>주문내역 조회</h2>
-          <ul>
-            <li>
-              <span>입금/결제 0</span>
-            </li>
-            <li>
-              <span>배송중/픽업대기 0</span>
-            </li>
-            <li>
-              <span>배송완료/픽업완료 0</span>
-            </li>
-            <li>
-              <span>구매확정 0</span>
-            </li>
-          </ul>
         </header>
         <div className={styles.grid_order}>
           <div className={styles.grid_header}>상품정보</div>

--- a/src/components/MyPage/MyPageReviewList/MyPageReviewListLayout.module.scss
+++ b/src/components/MyPage/MyPageReviewList/MyPageReviewListLayout.module.scss
@@ -1,34 +1,39 @@
 .reviewWrapper {
-  display: inline-block;
-  width: calc(100vw - 250px);
-  min-width: 1200px;
-  margin-bottom: 50px;
+  float: left;
+  margin-bottom: 120px;
+  margin-top: -32px;
+  padding-right: 40px;
+  width: calc(100% - 290px);
+  min-height: calc(100vh - 500px);
   .reviewHeader {
-    width: 100%;
-    height: 87px;
+    border-bottom: 3px solid #000000;
+    font-family: 'Musinsa', sans-serif !important;
+    font-size: 14px;
+    line-height: 1.5;
+    margin-top: 80px;
     padding-bottom: 14px;
-    border-bottom: 3px solid black;
-    margin-top: 48px;
-    display: inline-block;
+    position: relative;
     h1 {
-      font-weight: 400;
       display: inline-block;
-      margin-block-start: 0;
-      margin-block-end: 0;
+      font-family: 'Musinsa', sans-serif !important;
+      font-size: 24px;
+      font-weight: normal;
+      margin: 0;
     }
     .tabGroup {
       font-size: 18px;
       line-height: 27px;
       vertical-align: top;
-      margin-top: 15px;
+      margin-top: 10px;
       cursor: pointer;
-      .tabWrite {
-        color: #ccc;
+      color: #ccc;
+
+      .tabHistory {
+        color: #000000;
       }
     }
   }
   .info {
-    padding-top: 20px;
     font-size: 14px;
     display: inline-block;
     padding-left: 15px;
@@ -38,172 +43,173 @@
       color: #777777;
     }
   }
-  .reviewTable {
+  .grid_order {
+    display: grid;
+    grid-template-columns: 3fr 5fr 2fr;
     width: 100%;
-    .title {
-      text-align: center;
-      padding-left: 0;
-      border-top: 2px solid black;
-      position: relative;
-      height: 53px;
-      vertical-align: middle;
-      line-height: 53px;
-      .info {
-        display: inline-block;
-        width: 25%;
-        padding-left: 0;
-        padding-top: 0;
-        position: absolute;
-        left: 0;
-        border-bottom: 1px solid black;
-        font-size: 14px;
-        height: 53px;
-      }
-      .content {
-        display: inline-block;
-        width: 65%;
-        position: absolute;
-        left: 25%;
-        border-bottom: 1px solid black;
-        font-size: 14px;
-        height: 53px;
-      }
-      .type {
-        display: inline-block;
-        width: 10%;
-        position: absolute;
-        left: 90%;
-        border-bottom: 1px solid black;
-        font-size: 14px;
-        height: 53px;
-      }
-    }
-    .reviewList {
-      padding-left: 0;
-      margin-top: 0;
-      margin-bottom: 0;
-    }
+  }
+
+  .grid_orderitem {
+    display: grid;
+    grid-template-columns: 3fr 5fr 2fr;
+    width: 100%;
+    border-bottom: 1px solid #ccc;
+    align-items: center;
+  }
+
+  .grid_header {
+    display: flex;
+    border-top: 1px solid black;
+    border-bottom: 1px solid #000000;
+    font-size: 16px;
+    height: 52px;
+    justify-content: center;
+    line-height: 48px;
+    vertical-align: middle;
+  }
+
+  .grid_items {
+    display: flex;
+    font-size: 16px;
+    height: 150px;
+    justify-content: center;
+    line-height: 146px;
+    vertical-align: middle;
+  }
+
+  .grid_reviews {
+    padding: 0px 10px;
+    display: flex;
+    flex-direction: column;
+    font-size: 16px;
+    justify-content: center;
+    align-items: center;
+    vertical-align: middle;
   }
 }
 
-.reviewWrittenItem {
-  list-style-type: none;
-  position: relative;
-}
-.ItemInfo {
-  width: calc(25% - 20px);
-  padding-top: 21px;
-  padding-left: 10px;
-  padding-right: 10px;
-  display: inline-block;
-  img {
-    width: 80px;
-    height: 96px;
-    padding-left: 10px;
-  }
-  ul {
-    display: inline-block;
-    position: relative;
-    bottom: 30px;
-    padding-left: 10px;
-    li {
-      list-style-type: none;
-      width: 180px;
-    }
-  }
-}
-.ItemContent {
-  padding-top: 20px;
-  vertical-align: top;
-  width: 65%;
-  display: inline-block;
-  cursor: pointer;
-  .reviewDate {
-    padding-left: 21px;
-    margin-bottom: 15px;
-    span {
-      font-size: 12px;
-      color: #aaa;
-    }
-  }
-  .starWrap {
-    padding-left: 21px;
-    padding-bottom: 10px;
-    height: 14px;
-    position: relative;
-    right: 8px;
-    .star_background {
-      overflow: hidden;
-      width: 90px;
+.Item {
+  width: 100%;
+  padding: 5px;
+  display: flex;
+  flex-direction: row;
+  .ImageDiv {
+    flex: 3;
+    display: flex;
+    .previewImage {
       height: 100%;
-      background: url('../../../resources/image/big_stars_background.svg') no-repeat;
-      background-position: left top;
-      background-size: 90px 100%;
-    }
-    .star_bar {
+      margin: auto;
       display: block;
-      height: 100%;
-      background: url('../../../resources/image/big_stars.svg') no-repeat;
-      background-position: left top;
-      background-size: 90px 100%;
+      cursor: pointer;
     }
   }
-  .reviewContent {
-    padding-left: 21px;
-    .contentText {
-      width: 100%;
-    }
-    .contentValue {
-      padding-top: 10px;
-      .reviewEvaluationList {
-        display: flex;
-        justify-content: flex-start;
-        margin-block-start: 0px;
-        margin-block-end: 0px;
-        margin-inline-end: 0px;
-        margin-inline-start: 0px;
-        padding-inline-start: 0px;
-        .reviewEvaluationItem {
-          align-items: center;
-          box-sizing: border-box;
-          color: #777;
-          display: flex;
-          flex-direction: row;
-          font-size: 12px;
-          height: 25px;
-          text-align: left;
-          vertical-align: top;
-          padding: 0 8px;
-          border: 1px solid #eee;
-          border-radius: 20px;
-          margin-right: 5px;
+  .ItemInfo {
+    flex: 7;
+    padding-left: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    .InfoLine {
+      line-height: 25px;
+      .brand {
+        font-size: 14px;
+      }
 
-          span {
-            color: black;
-          }
+      .name {
+        font-weight: bold;
+        font-size: 14px;
+      }
+      .size {
+        color: #ccc;
+      }
+    }
+  }
+}
+
+.reviewDate {
+  padding: 10px 3px;
+  height: 30px;
+  line-height: 30px;
+  span {
+    font-size: 12px;
+    color: #aaa;
+  }
+  .editDelete {
+    cursor: pointer;
+  }
+}
+.starWrap {
+  height: 16px;
+  position: relative;
+  .star_background {
+    overflow: hidden;
+    width: 90px;
+    height: 100%;
+    background: url('../../../resources/image/big_stars_background.svg')
+      no-repeat;
+    background-position: left top;
+    background-size: 90px 100%;
+  }
+  .star_bar {
+    display: block;
+    height: 100%;
+    background: url('../../../resources/image/big_stars.svg') no-repeat;
+    background-position: left top;
+    background-size: 90px 100%;
+  }
+}
+.reviewContent {
+  width: 450px;
+  .contentText {
+    width: 440px;
+    padding: 10px 5px;
+    line-height: 16px;
+  }
+  .contentValue {
+    padding-bottom: 10px;
+    .reviewEvaluationList {
+      display: flex;
+      justify-content: flex-start;
+      margin-block-start: 0px;
+      margin-block-end: 0px;
+      margin-inline-end: 0px;
+      margin-inline-start: 0px;
+      padding-inline-start: 0px;
+      .reviewEvaluationItem {
+        align-items: center;
+        box-sizing: border-box;
+        color: #777;
+        display: flex;
+        flex-direction: row;
+        font-size: 12px;
+        height: 25px;
+        text-align: left;
+        vertical-align: top;
+        padding: 0 8px;
+        border: 1px solid #eee;
+        border-radius: 20px;
+        margin-right: 5px;
+
+        span {
+          color: black;
         }
       }
     }
   }
-  .commentCount {
-    padding-left: 21px;
-    padding-top: 20px;
-    font-weight: 700;
-    span {
-      color: #0078ff;
-    }
+}
+.commentCount {
+  padding: 10px;
+  font-weight: 700;
+  b {
+    padding: 0px 5px;
+    cursor: pointer;
+  }
+  span {
+    cursor: pointer;
+    color: #0078ff;
   }
 }
 
-.reviewType {
-  text-align: center;
-  width: 10%;
-  display: inline-block;
-  position: absolute;
-  top: 50%;
-
-
-}
 .reviewComment {
   padding-left: calc(25% + 21px);
   padding-bottom: 10px;

--- a/src/components/MyPage/MyPageReviewList/MyPageReviewListLayout.tsx
+++ b/src/components/MyPage/MyPageReviewList/MyPageReviewListLayout.tsx
@@ -1,18 +1,22 @@
 import styles from './MyPageReviewListLayout.module.scss';
 import { Review, Comment } from '../../../lib/interface';
 import React, { useState } from 'react';
-import { getRelativeDateTime } from '../../../lib/formatters/dateTimeFormatter';
+import {
+  formatDate,
+  getRelativeDateTime,
+} from '../../../lib/formatters/dateTimeFormatter';
 import {
   formatColorReview,
   formatSizeReview,
 } from '../../../lib/formatters/reviewFormatter';
 import { getBarWidth } from '../../../lib/formatters/ratingFormatter';
+import { useNavigate } from 'react-router-dom';
 interface MyPageReviewListLayoutParams {
   onClickWrite: () => void;
   data: Review[] | undefined;
   onEdit: (data: Review) => void;
   onRemove: (id: number) => void;
-  temp: number[]
+  temp: number[];
 }
 interface ReviewWrittenItemParams {
   data: Review;
@@ -84,6 +88,7 @@ function ReviewWrittenItem({
   onEdit,
   onRemove,
 }: ReviewWrittenItemParams) {
+  const navigate = useNavigate();
   const [showComment, setShowComment] = useState<boolean>(false);
   const onClick = () => {
     if (showComment === false) {
@@ -93,78 +98,170 @@ function ReviewWrittenItem({
     }
   };
   return (
-    <li className={styles.reviewWrittenItem}>
-      <div className={styles.ItemInfo}>
-        <a href={`http://localhost:3000/goods/${data.purchase.item.id}`}>
-          <img
-            src={data.purchase.item.images[0]}
-            alt={data.purchase.item.name}
-          />
-        </a>
-        <ul>
-          <li>{data.purchase.item.brand}</li>
-          <li>
-            <b>{data.purchase.item.name}</b>
-          </li>
-          <li>{data.purchase.option}</li>
-        </ul>
-      </div>
-      <div className={styles.ItemContent} onClick={onClick}>
-        <div className={styles.reviewDate}>
-          <span>{getRelativeDateTime(data.createdDateTime)}</span>
-          <span
-            onClick={() => {
-              onEdit(data);
-            }}
-          >
-            {' '}
-            &nbsp;&nbsp;수정 |
-          </span>
-          <span
-            onClick={() => {
-              onRemove(data.id);
-            }}
-          >
-            {' '}
-            삭제
-          </span>
-        </div>
-        <div className={styles.starWrap}>
-          <span className={styles.star_background}>
-            <span
-              className={styles.star_bar}
-              style={{
-                width: `${getBarWidth(data.rating)}%`,
+    // <li className={styles.reviewWrittenItem}>
+    //   <div className={styles.ItemInfo}>
+    //     <a href={`http://localhost:3000/goods/${data.purchase.item.id}`}>
+    //       <img
+    //         src={data.purchase.item.images[0]}
+    //         alt={data.purchase.item.name}
+    //       />
+    //     </a>
+    //     <ul>
+    //       <li>{data.purchase.item.brand}</li>
+    //       <li>
+    //         <b>{data.purchase.item.name}</b>
+    //       </li>
+    //       <li>{data.purchase.option}</li>
+    //     </ul>
+    //   </div>
+    //   <div className={styles.ItemContent} onClick={onClick}>
+    //     <div className={styles.reviewDate}>
+    //       <span>{getRelativeDateTime(data.createdDateTime)}</span>
+    //       <span
+    //         onClick={() => {
+    //           onEdit(data);
+    //         }}
+    //       >
+    //         {' '}
+    //         &nbsp;&nbsp;수정 |
+    //       </span>
+    //       <span
+    //         onClick={() => {
+    //           onRemove(data.id);
+    //         }}
+    //       >
+    //         {' '}
+    //         삭제
+    //       </span>
+    //     </div>
+    //     <div className={styles.starWrap}>
+    //       <span className={styles.star_background}>
+    //         <span
+    //           className={styles.star_bar}
+    //           style={{
+    //             width: `${getBarWidth(data.rating)}%`,
+    //           }}
+    //         />
+    //       </span>
+    //     </div>
+    //     <div className={styles.reviewContent}>
+    //       <div className={styles.contentText}>{data.content}</div>
+    //       <div className={styles.contentValue}>
+    //         <ul className={styles.reviewEvaluationList}>
+    //           <li className={styles.reviewEvaluationItem}>
+    //             사이즈&nbsp;
+    //             <span>{formatSizeReview(data.size)}</span>
+    //           </li>
+    //           <li className={styles.reviewEvaluationItem}>
+    //             색감&nbsp;
+    //             <span>{formatColorReview(data.color)}</span>
+    //           </li>
+    //         </ul>
+    //       </div>
+    //     </div>
+    //     <div className={styles.commentCount}>
+    //       댓글 <span>{data.comments.length}</span>
+    //     </div>
+    //   </div>
+    //   <div className={styles.reviewType}>일반</div>
+    //   {showComment ? (
+    //     <div className={styles.reviewComment}>
+    //       <ReviewCommentList data={data.comments} />
+    //     </div>
+    //   ) : null}
+    // </li>
+    <div className={styles.grid_orderitem}>
+      <div className={styles.grid_items}>
+        <div className={styles.Item}>
+          <div className={styles.ImageDiv}>
+            <img
+              className={styles.previewImage}
+              src={data.purchase.item.images[0]}
+              alt="상품 이미지"
+              onClick={() => {
+                navigate(`/goods/${data.purchase.item.id}`);
               }}
             />
-          </span>
-        </div>
-        <div className={styles.reviewContent}>
-          <div className={styles.contentText}>{data.content}</div>
-          <div className={styles.contentValue}>
-            <ul className={styles.reviewEvaluationList}>
-              <li className={styles.reviewEvaluationItem}>
-                사이즈&nbsp;
-                <span>{formatSizeReview(data.size)}</span>
-              </li>
-              <li className={styles.reviewEvaluationItem}>
-                색감&nbsp;
-                <span>{formatColorReview(data.color)}</span>
-              </li>
-            </ul>
+          </div>
+          <div className={styles.ItemInfo}>
+            <div className={styles.InfoLine}>
+              <span className={styles.brand}>{data.purchase.item.brand}</span>
+            </div>
+            <div className={styles.InfoLine}>
+              <span className={styles.name}>{data.purchase.item.name}</span>
+            </div>
+            <div className={styles.InfoLine}>
+              <span className={styles.size}>{data.purchase?.option}</span>
+            </div>
           </div>
         </div>
-        <div className={styles.commentCount}>
-          댓글 <span>{data.comments.length}</span>
+      </div>
+      <div className={styles.grid_reviews}>
+        <div>
+          <div className={styles.reviewDate}>
+            <span>{getRelativeDateTime(data.createdDateTime)}</span>
+            <span
+              className={styles.editDelete}
+              onClick={() => {
+                onEdit(data);
+              }}
+            >
+              {' '}
+              &nbsp;&nbsp;수정 |
+            </span>
+            <span
+              className={styles.editDelete}
+              onClick={() => {
+                onRemove(data.id);
+              }}
+            >
+              {' '}
+              삭제
+            </span>
+          </div>
+          <div className={styles.starWrap}>
+            <span className={styles.star_background}>
+              <span
+                className={styles.star_bar}
+                style={{
+                  width: `${getBarWidth(data.rating)}%`,
+                }}
+              />
+            </span>
+          </div>
+          <div className={styles.reviewContent}>
+            <div className={styles.contentText}>{data.content}</div>
+            <div className={styles.contentValue}>
+              <ul className={styles.reviewEvaluationList}>
+                <li className={styles.reviewEvaluationItem}>
+                  사이즈&nbsp;
+                  <span>{formatSizeReview(data.size)}</span>
+                </li>
+                <li className={styles.reviewEvaluationItem}>
+                  색감&nbsp;
+                  <span>{formatColorReview(data.color)}</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div className={styles.commentCount}>
+            <b onClick={onClick}>댓글</b>
+            <span onClick={onClick}>{data.comments.length}</span>
+          </div>
         </div>
       </div>
-      <div className={styles.reviewType}>일반</div>
+      <div className={styles.grid_items}>
+        <div className={styles.reviewType}>
+          {formatDate(data.createdDateTime)}
+          {data.modifiedDateTime ? '수정됨' : ''}
+        </div>
+      </div>
       {showComment ? (
         <div className={styles.reviewComment}>
           <ReviewCommentList data={data.comments} />
         </div>
       ) : null}
-    </li>
+    </div>
   );
 }
 export default function MyPageReviewListLayout({
@@ -172,7 +269,7 @@ export default function MyPageReviewListLayout({
   data,
   onEdit,
   onRemove,
-    temp,
+  temp,
 }: MyPageReviewListLayoutParams) {
   return (
     <div className={styles.reviewWrapper}>
@@ -180,7 +277,7 @@ export default function MyPageReviewListLayout({
         <h1>구매후기</h1>
         <div className={styles.tabGroup}>
           <span className={styles.tabWrite} onClick={onClickWrite}>
-            후기 작성&nbsp; /
+            후기 작성 /
           </span>
           <span className={styles.tabHistory}> 후기 내역</span>
         </div>
@@ -193,21 +290,23 @@ export default function MyPageReviewListLayout({
         <li>작성 시 관리자 확인 후 적립금이 지급됩니다.</li>
         <li>후기작성은 구매확정일로부터 90일까지 가능합니다.</li>
       </ul>
-      <div className={styles.reviewTable}>
-        <div className={styles.title}>
-          <span className={styles.info}>상품정보</span>
-          <span className={styles.content}>내용</span>
-          <span className={styles.type}>후기 종류</span>
-        </div>
 
-        <ul className={styles.reviewList}>
-          {data?.filter(review => temp.includes(review.id) === false).map((review=>(<ReviewWrittenItem
+      <div className={styles.grid_order}>
+        <span className={styles.grid_header}>상품정보</span>
+        <span className={styles.grid_header}>내용</span>
+        <span className={styles.grid_header}>작성 일자</span>
+      </div>
+      <>
+        {data
+          ?.filter((review) => temp.includes(review.id) === false)
+          .map((review) => (
+            <ReviewWrittenItem
               data={review}
               onEdit={onEdit}
               onRemove={onRemove}
-          />)))}
-        </ul>
-      </div>
+            />
+          ))}
+      </>
     </div>
   );
 }

--- a/src/components/MyPage/MyPageViewed/MyPageViewed.module.scss
+++ b/src/components/MyPage/MyPageViewed/MyPageViewed.module.scss
@@ -4,6 +4,7 @@
   margin-top: -32px;
   padding-right: 40px;
   width: calc(100% - 290px);
+  min-height: calc(100vh - 500px);
 }
 
 .title {

--- a/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsLayout.module.scss
+++ b/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsLayout.module.scss
@@ -1,24 +1,36 @@
 .reviewWrapper {
-  width: calc(100% - 250px);
-  display: inline-block;
+  float: left;
+  margin-bottom: 120px;
+  margin-top: -32px;
+  padding-right: 40px;
+  width: calc(100% - 290px);
+  min-height: calc(100vh - 500px);
   .reviewHeader {
-    width: 100%;
-    height: 36px;
+    border-bottom: 3px solid #000000;
+    font-family: 'Musinsa', sans-serif !important;
+    font-size: 14px;
+    line-height: 1.5;
+    margin-top: 80px;
     padding-bottom: 14px;
-    border-bottom: 3px solid black;
-    margin-top: 48px;
+    position: relative;
+  }
+  h1 {
+    display: inline-block;
+    font-family: 'Musinsa', sans-serif !important;
+    font-size: 24px;
+    font-weight: normal;
+    margin: 0;
   }
   ul {
     padding-left: 20px;
     li {
       margin-bottom: 5px;
       color: #777;
-
     }
   }
   .reviewWrite {
     width: 100%;
-    padding-top: 40px;
+    padding-top: 20px;
     .reviewItem {
       width: 100%;
       height: 96px;
@@ -137,9 +149,12 @@
         width: 100%;
         height: 228px;
         padding-bottom: 50px;
-        border: 1px solid black;
+        border: 1px solid #bbbbbb;
         font-size: 14px;
         position: relative;
+        :focus {
+          outline: none;
+        }
         .reviewWriteInput {
           width: calc(100% - 15px);
           height: 216px;
@@ -157,9 +172,12 @@
         width: 100%;
         height: 228px;
         padding-bottom: 50px;
-        border: 1px solid black;
+        border: 1px solid #bbbbbb;
         font-size: 14px;
         position: relative;
+        :focus {
+          outline: none;
+        }
         img {
           width: 64px;
           height: 64px;
@@ -184,23 +202,16 @@
         height: 40px;
         position: relative;
         bottom: 45px;
-        .textButton {
+        Button {
+          border: 1px solid #bbbbbb;
+          height: 25px;
+          line-height: 23px;
           width: 100px;
-          border-left: 0.1px solid #f3f3f3;
-          border-top: 0.1px solid #f3f3f3;
-          border-bottom: 0.1px solid #f3f3f3;
-          border-right: 0.5px solid black;
+          font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
           background-color: white;
-          margin-left: 5px;
-          cursor: pointer;
-        }
-        .imageButton {
-          width: 100px;
-          border-left: 0.5px solid black;
-          border-top: 0.1px solid #f3f3f3;
-          border-bottom: 0.1px solid #f3f3f3;
-          border-right: 0.1px solid #f3f3f3;
-          background-color: white;
+          border-radius: 5px;
+          color: black;
+          margin-left: 10px;
           cursor: pointer;
         }
       }
@@ -222,7 +233,8 @@
         background-color: black;
         color: white;
         box-sizing: border-box;
-        font-family: 'Musinsa', sans-serif !important;
+        font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+        cursor: pointer;
       }
     }
   }

--- a/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsListLayout.module.scss
+++ b/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsListLayout.module.scss
@@ -1,24 +1,30 @@
 .reviewWrapper {
-  display: inline-block;
-  width: 1270px;
+  float: left;
+  margin-bottom: 120px;
+  margin-top: -32px;
+  padding-right: 40px;
+  width: calc(100% - 290px);
+  min-height: calc(100vh - 500px);
   .reviewHeader {
-    width: 1270px;
-    height: 87px;
+    border-bottom: 3px solid #000000;
+    font-family: 'Musinsa', sans-serif !important;
+    font-size: 14px;
+    line-height: 1.5;
+    margin-top: 80px;
     padding-bottom: 14px;
-    border-bottom: 3px solid black;
-    margin-top: 48px;
-    display: inline-block;
+    position: relative;
     h1 {
-      font-weight: 400;
       display: inline-block;
-      margin-block-start: 0;
-      margin-block-end: 0;
+      font-family: 'Musinsa', sans-serif !important;
+      font-size: 24px;
+      font-weight: normal;
+      margin: 0;
     }
     .tabGroup {
       font-size: 18px;
       line-height: 27px;
       vertical-align: top;
-      margin-top: 15px;
+      margin-top: 10px;
       cursor: pointer;
       .tabHistory {
         color: #ccc;
@@ -26,7 +32,6 @@
     }
   }
   .info {
-    padding-top: 20px;
     font-size: 14px;
     display: inline-block;
     padding-left: 15px;
@@ -36,38 +41,82 @@
       color: #777777;
     }
   }
-  .reviewTable {
-    width: 1270px;
+  .grid_order {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr;
+    width: 100%;
+  }
+
+  .grid_header {
+    display: flex;
     border-top: 1px solid black;
+    border-bottom: 1px solid #000000;
+    font-size: 16px;
+    height: 52px;
+    justify-content: center;
+    line-height: 48px;
+    vertical-align: middle;
+  }
+
+  .grid_items {
+    display: flex;
+    border-bottom: 1px solid #ccc;
+    font-size: 16px;
+    height: 150px;
+    justify-content: center;
+    line-height: 146px;
+    vertical-align: middle;
   }
 }
-.reviewItemInfo {
-  width: 620px;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  img {
-    width: 80px;
-    height: 96px;
-    padding-left: 10px;
+
+.Item {
+  width: 100%;
+  padding: 5px;
+  display: flex;
+  flex-direction: row;
+  .ImageDiv {
+    flex: 3;
+    display: flex;
+    .previewImage {
+      height: 100%;
+      margin: auto;
+      display: block;
+      cursor: pointer;
+    }
   }
-  ul {
-    display: inline-block;
-    position: relative;
-    bottom: 30px;
-    padding-left: 10px;
-    li {
-      list-style-type: none;
+  .ItemInfo {
+    flex: 7;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    .InfoLine {
+      line-height: 25px;
+      .brand {
+        font-size: 14px;
+      }
+
+      .name {
+        font-weight: bold;
+        font-size: 14px;
+      }
+      .size {
+        color: #ccc;
+      }
     }
   }
 }
-.purchaseDate {
-  text-align: center;
+
+.buttonArea {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 }
+
 .reviewWriteButton {
-  width: 300px;
   background-color: #000000;
-  height: 50px;
-  margin-left: 8px;
+  width: 70%;
+  height: 60px;
   color: white;
   display: flex;
   justify-content: center;
@@ -76,26 +125,33 @@
   transition-duration: 0.3s;
 }
 .reviewWriteButton:hover {
-  width: 300px;
   background-color: #0071f1;
-  height: 50px;
-  margin-left: 8px;
+  width: 70%;
+  height: 60px;
   color: white;
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 16px;
-  cursor: pointer;
+  transition-duration: 0.3s;
 }
 .reviewWriteDone {
-  width: 300px;
   background-color: #f3f3f3;
-  height: 50px;
-  margin-left: 8px;
   color: #0078ff;
+  width: 70%;
+  height: 60px;
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 16px;
-  cursor: pointer;
+}
+
+.none {
+  align-items: center;
+  border-bottom: 1px solid #f5f5f5;
+  color: #777777;
+  display: flex;
+  font-size: 14px;
+  height: 400px;
+  justify-content: center;
 }

--- a/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsListLayout.tsx
+++ b/src/components/MyPage/MyPageWriteReviews/MyPageWriteReviewsListLayout.tsx
@@ -1,6 +1,7 @@
 import styles from './MyPageWriteReviewsListLayout.module.scss';
 import { Purchase } from '../../../lib/interface';
 import { formatDate } from '../../../lib/formatters/dateTimeFormatter';
+import { useNavigate } from 'react-router-dom';
 
 interface ReviewItemParams {
   data: Purchase;
@@ -8,44 +9,59 @@ interface ReviewItemParams {
 }
 
 function ReviewItem({ data, onClick }: ReviewItemParams) {
+  const navigate = useNavigate();
+
   return (
-    <tr>
-      <td>
-        <div className={styles.reviewItemInfo}>
-          <a href={`/goods/${data?.item.id}`}>
-            <img src={data?.item.images[0]} alt="아이템 사진" />
-          </a>
-          <ul>
-            <li>{data?.item.brand}</li>
-            <li>
-              <b>{data?.item.name}</b>
-            </li>
-            <li>{data?.option}</li>
-          </ul>
-        </div>
-      </td>
-      <td className={styles.purchaseDate}>
-        {formatDate(data.createdDateTime)}
-        <br />
-        구매확정
-      </td>
-      {data?.isReviewed ? (
-        <td>
-          <div className={styles.reviewWriteDone}>후기 작성완료</div>
-        </td>
-      ) : (
-        <td>
-          <div
-            className={styles.reviewWriteButton}
-            onClick={() => {
-              onClick(data);
-            }}
-          >
-            후기 작성하러가기
+    <div className={styles.grid_order}>
+      <div className={styles.grid_items}>
+        <div className={styles.Item}>
+          <div className={styles.ImageDiv}>
+            <img
+              className={styles.previewImage}
+              src={data?.item.images[0]}
+              alt="상품 이미지"
+              onClick={() => {
+                navigate(`/goods/${data.item.id}`);
+              }}
+            />
           </div>
-        </td>
+          <div className={styles.ItemInfo}>
+            <div className={styles.InfoLine}>
+              <span className={styles.brand}>{data?.item.brand}</span>
+            </div>
+            <div className={styles.InfoLine}>
+              <span className={styles.name}>{data?.item.name}</span>
+            </div>
+            <div className={styles.InfoLine}>
+              <span className={styles.size}>{data?.option}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className={styles.grid_items}>
+        구매확정 / {formatDate(data.createdDateTime)}
+      </div>
+      {data?.isReviewed ? (
+        <div className={styles.grid_items}>
+          <div className={styles.buttonArea}>
+            <div className={styles.reviewWriteDone}>후기 작성완료</div>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.grid_items}>
+          <div className={styles.buttonArea}>
+            <div
+              className={styles.reviewWriteButton}
+              onClick={() => {
+                onClick(data);
+              }}
+            >
+              후기 작성하러가기
+            </div>
+          </div>
+        </div>
       )}
-    </tr>
+    </div>
   );
 }
 interface MyPageWriteReviewsListLayoutParams {
@@ -65,7 +81,9 @@ export default function MyPageWriteReviewsListLayout({
         <h1>구매후기</h1>
         <div className={styles.tabGroup}>
           <span className={styles.tabWrite}>후기 작성&nbsp;</span>
-          <span className={styles.tabHistory} onClick={onClickReviewList}> / 후기 내역</span>
+          <span className={styles.tabHistory} onClick={onClickReviewList}>
+            {''}/ 후기 내역
+          </span>
         </div>
       </header>
       <ul className={styles.info}>
@@ -76,29 +94,20 @@ export default function MyPageWriteReviewsListLayout({
         <li>작성 시 관리자 확인 후 적립금이 지급됩니다.</li>
         <li>후기작성은 구매확정일로부터 90일까지 가능합니다.</li>
       </ul>
-      <table className={styles.reviewTable}>
-        <colgroup>
-          <col width="*"></col>
-          <col width="25%"></col>
-          <col width="25%"></col>
-        </colgroup>
-        <thead>
-          <tr>
-            <th scope="col">상품정보</th>
-            <th scope="col">구매 / 구매확정일</th>
-            <th scope="col">후기 작성</th>
-          </tr>
-        </thead>
-        {purchases && purchases?.length !== 0 ? (
-          <tbody>
-            {purchases.map((item) => (
-              <ReviewItem data={item} onClick={onClick} key={item.id} />
-            ))}
-          </tbody>
-        ) : (
-          <div>후기 작성할 목록이 없습니다.</div>
-        )}
-      </table>
+      <div className={styles.grid_order}>
+        <div className={styles.grid_header}>상품정보 </div>
+        <div className={styles.grid_header}>구매 / 구매확정일 </div>
+        <div className={styles.grid_header}>후기 작성 </div>
+      </div>
+      {purchases && purchases?.length !== 0 ? (
+        <>
+          {purchases.map((item) => (
+            <ReviewItem data={item} onClick={onClick} key={item.id} />
+          ))}
+        </>
+      ) : (
+        <div className={styles.none}>작성할 후기가 없습니다.</div>
+      )}
     </div>
   );
 }

--- a/src/components/MyPage/index.tsx
+++ b/src/components/MyPage/index.tsx
@@ -82,10 +82,6 @@ function MyPage() {
             element={<div>/mypage/item_inquiry</div>}
           />
           <Route
-            path="personal_inquiry"
-            element={<div>/mypage/personal_inquiry</div>}
-          />
-          <Route
             path="viewed_goods"
             element={<MyPageViewed accessToken={accessToken} />}
           />

--- a/src/components/PurchasePage/PurchasePageHeader.tsx
+++ b/src/components/PurchasePage/PurchasePageHeader.tsx
@@ -5,7 +5,7 @@ export default function PurchasePageHeader() {
     <>
       <div className={styles.pagenation}>
         <div className={styles.nav_sub}>
-          <a href="/">무신사 스토어</a>
+          <span>무신사 스토어</span>
           <span className={styles.iconEntity}>{'>'}</span>
           <span>주문서</span>
         </div>

--- a/src/components/PurchasePage/index.tsx
+++ b/src/components/PurchasePage/index.tsx
@@ -1,7 +1,6 @@
 import styles from './index.module.scss';
 import OrderProductInfo from './OrderProductInfo';
 import PurchasePageHeader from './PurchasePageHeader';
-import OrderDelivery from './OrderDelivery';
 import { Purchase } from '../../lib/interface';
 import OrderPurchase from './OrderPurchase';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -60,6 +59,7 @@ export default function PurchasePage() {
 
   useEffect(() => {
     if (!purchaseList || purchaseList?.length === 0) {
+      toast('구매할 상품이 없습니다.');
       navigate(-1);
     }
   }, [purchaseList, navigate]);
@@ -146,7 +146,7 @@ export default function PurchasePage() {
     <div className={styles.wrap}>
       <PurchasePageHeader />
       <div className={styles.f1}>
-        <OrderDelivery />
+        {/* <OrderDelivery /> */}
         <OrderProductInfo purchaseList={purchaseList} />
         <OrderPurchase
           purchaseList={purchaseList}

--- a/src/components/ShoppingCart/ShopppingCartHeader.module.scss
+++ b/src/components/ShoppingCart/ShopppingCartHeader.module.scss
@@ -16,11 +16,9 @@
     background: transparent;
   }
 
-  a {
-    text-decoration: none;
-  }
-  a:hover {
+  .navi:hover {
     text-decoration: underline;
+    cursor: pointer;
   }
 
   .iconEntity {

--- a/src/components/ShoppingCart/ShopppingCartHeader.tsx
+++ b/src/components/ShoppingCart/ShopppingCartHeader.tsx
@@ -5,11 +5,9 @@ export default function ShopppingCartHeader() {
     <>
       <div className={styles.pagenation}>
         <div className={styles.nav_sub}>
-          <a href="/">무신사 스토어</a>
+          <span>무신사 스토어</span>
           <span className={styles.iconEntity}>{'>'}</span>
-          <a href="/mypage">마이페이지</a>
-          <span className={styles.iconEntity}>{'>'}</span>
-          <span>장바구니</span>
+          <span className={styles.navi}>장바구니</span>
         </div>
       </div>
       <div className={styles.rightContents}>


### PR DESCRIPTION
 + Closet : 다른 사람 페이지에서는 헤더상단에 My Closet이 아니라 Closet으로 렌더 되도록 설정
 + MyPage : 1:1문의 탭 삭제, 구매후기 탭 전반적인 구조, css 개선, 사진 누르면 detailPage navigate
 + Header : 주문배송조회 > 주문내역조회
 + PurchasePage : a링크 때문에 보라색으로 글씨뜨는거 없앰, 배송지 탭 삭제, 구매목록 비었는데 진입 시 toast띄우고 navigate -1
 
 로직 건드리거나 한게 없어서 회의전에 합쳐지면 좋을 것 같은데 노룩머지 가능할까요?